### PR TITLE
Handle captcha timeouts and incorrect answers

### DIFF
--- a/src/devpulse_client/queue/event_store.py
+++ b/src/devpulse_client/queue/event_store.py
@@ -60,9 +60,26 @@ class _CaptchaCancelledEvent:
     expression: str
     correct_answer: int
 
+@dataclass()
+class _CaptchaNotAnsweredEvent:
+    username: str
+    timestamp: datetime
+    event: str
+    expression: str
+    correct_answer: int
+
+@dataclass()
+class _WrongCaptchaAnswerEvent:
+    username: str
+    timestamp: datetime
+    event: str
+    expression: str
+    user_answer: int
+    correct_answer: int
+
 class EventStore:
     
-    _events: Deque[_ActivityEvent | _HeartbeatEvent | _WindowEvent | _CaptchaCreatedEvent | _CaptchaAnsweredEvent | _CaptchaCancelledEvent] = deque() 
+    _events: Deque[_ActivityEvent | _HeartbeatEvent | _WindowEvent | _CaptchaCreatedEvent | _CaptchaAnsweredEvent | _CaptchaCancelledEvent | _CaptchaNotAnsweredEvent | _WrongCaptchaAnswerEvent] = deque() 
     
 
     @staticmethod
@@ -157,6 +174,33 @@ class EventStore:
                 user_answer=user_answer,
                 correct_answer=correct_answer,
                 is_correct=is_correct,
+            )
+        )
+
+    @staticmethod
+    def log_captcha_not_answered(expression: str, correct_answer: int, timestamp: datetime | None = None) -> None:
+        ts = timestamp or datetime.now()
+        EventStore._push(
+            _CaptchaNotAnsweredEvent(
+                username=tracker_settings.user,
+                timestamp=ts,
+                event="captcha_not_answered",
+                expression=expression,
+                correct_answer=correct_answer,
+            )
+        )
+
+    @staticmethod
+    def log_wrong_captcha_answer(expression: str, user_answer: int, correct_answer: int, timestamp: datetime | None = None) -> None:
+        ts = timestamp or datetime.now()
+        EventStore._push(
+            _WrongCaptchaAnswerEvent(
+                username=tracker_settings.user,
+                timestamp=ts,
+                event="wrong_captcha_answer",
+                expression=expression,
+                user_answer=user_answer,
+                correct_answer=correct_answer,
             )
         )
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add `captcha_not_answered` event when a captcha expires and `wrong_captcha_answer` event with immediate re-prompt on incorrect input.

---
<a href="https://cursor.com/background-agent?bcId=bc-2ee316e9-074b-479d-bf0d-da700f9d2318">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2ee316e9-074b-479d-bf0d-da700f9d2318">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>